### PR TITLE
Disable audio to reduce warnings

### DIFF
--- a/com.lablicate.OpenChrom.yaml
+++ b/com.lablicate.OpenChrom.yaml
@@ -9,7 +9,6 @@ finish-args:
 - --share=ipc
 - --device=dri
 - --share=network
-- --socket=pulseaudio
 - --persist=.openchrom
 - --persist=.eclipse/org.eclipse.swtchart.extensions
 - --filesystem=/tmp:rw


### PR DESCRIPTION
I don't think we need this. There is no audio playback and @flatpak does not differentiate input/output so it scares about this application spying on you via the microphone, which is utter nonsense.