### PR TITLE
Disable update in flatpak

### DIFF
--- a/com.lablicate.OpenChrom.yaml
+++ b/com.lablicate.OpenChrom.yaml
@@ -21,6 +21,7 @@ modules:
     no-debuginfo: true
   build-commands:
   - mv openchrom ${FLATPAK_DEST}/openchrom/
+  - sed -i 's;-Dopenchrom.update=true;-Dopenchrom.update=false;' ${FLATPAK_DEST}/openchrom/openchrom.ini
   - mkdir -p ${FLATPAK_DEST}/bin
   - ln -sf ${FLATPAK_DEST}/openchrom/openchrom ${FLATPAK_DEST}/bin/
   - install -Dm644 ${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop


### PR DESCRIPTION
Openchrom enables inplace updates via
https://github.com/OpenChrom/openchrom/commit/d80a255b2f8023a78778dd80631f815d77134983 . This is not wanted for flatpak which handles the updating differently.